### PR TITLE
Adds non-browser-based test script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+cypress.json

--- a/README.md
+++ b/README.md
@@ -178,3 +178,15 @@ As mentioned below in best practices please _make sure your tests are always iso
 - Don't use the previous test result for granted for next result. If the login passes in previous test you should login again for the new test even if it takes slightly more time.
 - Don't do things like `cy.wait(5000 seconds)` these are arbitrary and prone to failure depending on request and execution time.
 - You can add the constants and files on `cypress/fixtures` — for example, the `cypress/fixtures/sample.csv` which can be used in commands and tests.
+
+#### Non-browser based integration test
+
+There is also a script to use [CKAN JavaScript client](https://github.com/datopian/ckan-client-js) to run in integration test:
+
+```console
+$ node ntegration_test_with_ckan_client.js <ORGANIZATION NAME>
+```
+
+This script requires a CKAN instance set with an organization.
+
+In the future this script will be integrated into the Cypress set of test specs.

--- a/integration_test_with_ckan_client.js
+++ b/integration_test_with_ckan_client.js
@@ -1,0 +1,38 @@
+// TODO implement this as a Cypress spec
+
+import fs from "fs";
+import ckan from "ckan-client";
+import f11s from "frictionless.js";
+
+const uuid = () => Math.random().toString(36).slice(2) + "_test";
+const packageName = uuid();
+const orgName = process.argv[2];
+const config = JSON.parse(fs.readFileSync("cypress.json"));
+const client = new ckan.Client(
+  config.env.API_KEY,
+  orgName,
+  packageName,
+  config.baseUrl,
+  config.baseUrl + "/_giftless"
+);
+
+const run = async () => {
+  const dataset = await client.create({
+    name: packageName,
+    owner_org: orgName,
+  });
+  const resource = f11s.open("cypress/fixtures/sample.csv");
+  const resp = await client.pushBlob(resource);
+  return resp;
+};
+
+run()
+  .then(() => {
+    console.log("OK");
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.error("FAIL");
+    console.log(err);
+    process.exit(1);
+  });

--- a/package-lock.json
+++ b/package-lock.json
@@ -88,6 +88,14 @@
         "any-observable": "^0.3.0"
       }
     },
+    "@types/csv-parse": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@types/csv-parse/-/csv-parse-1.2.2.tgz",
+      "integrity": "sha512-k33tLtRKTQxf7hQfMlkWoS2TQYsnpk1ibZN+rzbuCkeBs8m23nHTeDTF1wb/e7/MSLdtgCzqu3oM1I101kd6yw==",
+      "requires": {
+        "csv-parse": "*"
+      }
+    },
     "@types/sinonjs__fake-timers": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.1.tgz",
@@ -97,6 +105,15 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.2.tgz",
       "integrity": "sha512-7EJYyKTL7tFR8+gDbB6Wwz/arpGa0Mywk1TJbNzKzHtzbwVmY4HR9WqS5VV7dsBUKQmPNr192jHr/VpBluj/hg=="
+    },
+    "adler-32": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.2.0.tgz",
+      "integrity": "sha1-aj5r8KY5ALoVZSgIyxXGgT0aXyU=",
+      "requires": {
+        "exit-on-epipe": "~1.0.1",
+        "printj": "~1.1.0"
+      }
     },
     "ajv": {
       "version": "6.12.3",
@@ -128,6 +145,11 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/any-observable/-/any-observable-0.3.0.tgz",
       "integrity": "sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog=="
+    },
+    "any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8="
     },
     "arch": {
       "version": "2.1.2",
@@ -166,6 +188,14 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.0.tgz",
       "integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA=="
+    },
+    "axios": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
+      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+      "requires": {
+        "follow-redirects": "1.5.10"
+      }
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -214,6 +244,16 @@
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
+    "cfb": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.0.tgz",
+      "integrity": "sha512-sXMvHsKCICVR3Naq+J556K+ExBo9n50iKl6LGarlnvuA2035uMlGA/qVrc0wQtow5P1vJEw9UyrKLCbtIKz+TQ==",
+      "requires": {
+        "adler-32": "~1.2.0",
+        "crc-32": "~1.2.0",
+        "printj": "~1.1.2"
+      }
+    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -242,6 +282,11 @@
         }
       }
     },
+    "chardet": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-1.3.0.tgz",
+      "integrity": "sha512-cyTQGGptIjIT+CMGT5J/0l9c6Fb+565GCFjjeUTKxUO7w3oR+FcNCMEKTn5xtVKaLFmladN7QF68IiQsv5Fbdw=="
+    },
     "check-more-types": {
       "version": "2.24.0",
       "resolved": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.24.0.tgz",
@@ -251,6 +296,16 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
       "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="
+    },
+    "ckan-client": {
+      "version": "git+https://github.com/datopian/ckan-client-js.git#f59a13b15b14cbbf0053201af0ccf15150a1b2ae",
+      "from": "git+https://github.com/datopian/ckan-client-js.git",
+      "requires": {
+        "axios": "^0.19.2",
+        "crypto-js": "^4.0.0",
+        "frictionless-ckan-mapper-js": "^1.0.0",
+        "frictionless.js": "^0.13.3"
+      }
     },
     "cli-cursor": {
       "version": "1.0.2",
@@ -303,6 +358,22 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+    },
+    "codepage": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.14.0.tgz",
+      "integrity": "sha1-jL4lSBMjVZ19MHVxsP/5HnodL5k=",
+      "requires": {
+        "commander": "~2.14.1",
+        "exit-on-epipe": "~1.0.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.14.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.14.1.tgz",
+          "integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw=="
+        }
+      }
     },
     "color-convert": {
       "version": "1.9.3",
@@ -362,6 +433,15 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
+    "crc-32": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.0.tgz",
+      "integrity": "sha512-1uBwHxF+Y/4yF5G48fwnKq6QsIXheor3ZLPT80yGBV1oEUwpPojlEhQbWKVw1VwcTQyMGHK1/XMmTjmlsmTTGA==",
+      "requires": {
+        "exit-on-epipe": "~1.0.1",
+        "printj": "~1.1.0"
+      }
+    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -373,6 +453,21 @@
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
       }
+    },
+    "crypto-js": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.0.0.tgz",
+      "integrity": "sha512-bzHZN8Pn+gS7DQA6n+iUmBfl0hO5DJq++QP3U6uTucDtk/0iGpXd/Gg7CGR0p8tJhofJyaKoWBuJI4eAO00BBg=="
+    },
+    "csv-parse": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-4.12.0.tgz",
+      "integrity": "sha512-wPQl3H79vWLPI8cgKFcQXl0NBgYYEqVnT1i6/So7OjMpsI540oD7p93r3w6fDSyPvwkTepG05F69/7AViX2lXg=="
+    },
+    "csv-sniffer": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/csv-sniffer/-/csv-sniffer-0.1.1.tgz",
+      "integrity": "sha1-1kEBdygARhV2e23Oic4gdu+w8Lc="
     },
     "cypress": {
       "version": "4.10.0",
@@ -474,6 +569,11 @@
         "once": "^1.4.0"
       }
     },
+    "es6-error": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="
+    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -510,6 +610,11 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
       "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g="
+    },
+    "exit-on-epipe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/exit-on-epipe/-/exit-on-epipe-1.0.1.tgz",
+      "integrity": "sha512-h2z5mrROTxce56S+pnvAV890uu7ls7f1kEvVGJbw1OlFH3/mlJ5bkXu0KRyW94v37zzHPiUd55iLn3DA7TjWpw=="
     },
     "extend": {
       "version": "3.0.2",
@@ -574,6 +679,29 @@
         "object-assign": "^4.1.0"
       }
     },
+    "follow-redirects": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+      "requires": {
+        "debug": "=3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -587,6 +715,43 @@
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
         "mime-types": "^2.1.12"
+      }
+    },
+    "frac": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
+      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA=="
+    },
+    "frictionless-ckan-mapper-js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/frictionless-ckan-mapper-js/-/frictionless-ckan-mapper-js-1.0.0.tgz",
+      "integrity": "sha512-/6/5ECgB1sBuKmgbeXHFi4yiSudZszaGUOhlbsqMybGy9IAFwPX8Pu6rqN7aXjTvzWTUJ0bTh2LsNaB9EuPugQ=="
+    },
+    "frictionless.js": {
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/frictionless.js/-/frictionless.js-0.13.3.tgz",
+      "integrity": "sha512-9cG+XmzmxkD9rKgdEYQagprm8nnSVe6GWWQekzhbyn8aUljfGO+pOobPat0FnnYuhiWu/TZCpqSz90MfX10Quw==",
+      "requires": {
+        "chardet": "1.3.0",
+        "csv-parse": "4.12.0",
+        "csv-sniffer": "0.1.1",
+        "iconv-lite": "0.6.2",
+        "lodash": "4.17.20",
+        "mime-types": "2.1.27",
+        "node-fetch": "2.6.1",
+        "readable-web-to-node-stream": "^2.0.0",
+        "stream-to-array": "2.3.0",
+        "stream-to-string": "1.2.0",
+        "tableschema": "1.12.3",
+        "url-join": "4.0.1",
+        "xlsx": "0.16.7"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+        }
       }
     },
     "fs-extra": {
@@ -689,6 +854,14 @@
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
         "sshpk": "^1.7.0"
+      }
+    },
+    "iconv-lite": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.2.tgz",
+      "integrity": "sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==",
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
       }
     },
     "indent-string": {
@@ -1047,6 +1220,11 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
     },
+    "node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+    },
     "npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
@@ -1128,10 +1306,20 @@
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.3.0.tgz",
       "integrity": "sha512-hjGrh+P926p4R4WbaB6OckyRtO0F0/lQBiT+0gnxjV+5kjPBrfVBFCsCLbMqVQeydvIoouYTCmmEURiH3R1Bdg=="
     },
+    "printj": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/printj/-/printj-1.1.2.tgz",
+      "integrity": "sha512-zA2SmoLaxZyArQTOPj5LXecR+RagfPSU5Kw1qP+jkWeNlrq+eJZyY2oS68SU1Z/7/myXM4lo9716laOFAVStCQ=="
+    },
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
+    "promise-polyfill": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-1.1.6.tgz",
+      "integrity": "sha1-zQTv9G9clcOn0EVZHXm14+AfEtc="
     },
     "psl": {
       "version": "1.8.0",
@@ -1187,6 +1375,16 @@
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         }
       }
+    },
+    "readable-web-to-node-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-2.0.0.tgz",
+      "integrity": "sha512-+oZJurc4hXpaaqsN68GoZGQAQIA3qr09Or4fqEsargABnbe5Aau8hFn6ISVleT3cpY/0n/8drn7huyyEvTbghA=="
+    },
+    "regenerator-runtime": {
+      "version": "0.13.7",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
     },
     "request-progress": {
       "version": "3.0.0",
@@ -1259,6 +1457,14 @@
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
       "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU="
     },
+    "ssf": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
+      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
+      "requires": {
+        "frac": "~1.1.2"
+      }
+    },
     "sshpk": {
       "version": "1.16.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
@@ -1273,6 +1479,27 @@
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
+      }
+    },
+    "stream-to-array": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/stream-to-array/-/stream-to-array-2.3.0.tgz",
+      "integrity": "sha1-u/azn19D7DC8cbq8s3VXrOzzQ1M=",
+      "requires": {
+        "any-promise": "^1.1.0"
+      }
+    },
+    "stream-to-async-iterator": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/stream-to-async-iterator/-/stream-to-async-iterator-0.2.0.tgz",
+      "integrity": "sha1-vvXIhelST5iy+l7/7MNXvVhIN4A="
+    },
+    "stream-to-string": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/stream-to-string/-/stream-to-string-1.2.0.tgz",
+      "integrity": "sha512-8drZlFIKBHSMdX9GCWv8V9AAWnQcTqw0iAI6/GC7UJ0H0SwKeFKjOoZfGY1tOU00GGU7FYZQoJ/ZCUEoXhD7yQ==",
+      "requires": {
+        "promise-polyfill": "^1.1.6"
       }
     },
     "string-width": {
@@ -1347,10 +1574,50 @@
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
       "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
     },
+    "tableschema": {
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/tableschema/-/tableschema-1.12.3.tgz",
+      "integrity": "sha512-957Zzq8NKVAzv3fp33NXbmDOp+oj5NaGjoyb9ZAh4LLwNYRJZSaYvo5zkLO+3St/Tc7ECbeEdfX11cAYZZKgLw==",
+      "requires": {
+        "@types/csv-parse": "^1.2.2",
+        "axios": "^0.19.2",
+        "csv-parse": "~4.8.8",
+        "csv-sniffer": "^0.1.1",
+        "es6-error": "^4.1.1",
+        "lodash": "^4.17.15",
+        "moment": "~2.24.0",
+        "regenerator-runtime": "^0.13.5",
+        "stream-to-async-iterator": "^0.2.0",
+        "through2": "^3.0.1",
+        "tv4": "^1.3.0",
+        "validator": "^13.0.0"
+      },
+      "dependencies": {
+        "csv-parse": {
+          "version": "4.8.9",
+          "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-4.8.9.tgz",
+          "integrity": "sha512-uDxIDIDLb89gxqixSgGqDj3EA5A8D0pgUeyp9Qut8u+eCIC8IXkTtaxJEnnWDb6N2HqBY64suSlcOGg5ZBtsAQ=="
+        },
+        "moment": {
+          "version": "2.24.0",
+          "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+          "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
+        }
+      }
+    },
     "throttleit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.0.tgz",
       "integrity": "sha1-nnhYNtr0Z0MUWlmEtiaNgoUorGw="
+    },
+    "through2": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
+      "integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
+      "requires": {
+        "inherits": "^2.0.4",
+        "readable-stream": "2 || 3"
+      }
     },
     "tmp": {
       "version": "0.1.0",
@@ -1381,6 +1648,11 @@
       "requires": {
         "safe-buffer": "^5.0.1"
       }
+    },
+    "tv4": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tv4/-/tv4-1.3.0.tgz",
+      "integrity": "sha1-0CDIRvrdUMhVq7JeuuzGj8EPeWM="
     },
     "tweetnacl": {
       "version": "0.14.5",
@@ -1426,6 +1698,11 @@
         }
       }
     },
+    "url-join": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA=="
+    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -1435,6 +1712,11 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+    },
+    "validator": {
+      "version": "13.1.17",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.1.17.tgz",
+      "integrity": "sha512-zL5QBoemJ3jYFb2/j38y7ljhwYGXVLUp8H6W1nVxadnAOvUOytec+L7BHh1oBQ82/TzWXHd+GSaxUWp4lROkLg=="
     },
     "verror": {
       "version": "1.10.0",
@@ -1453,6 +1735,16 @@
       "requires": {
         "isexe": "^2.0.0"
       }
+    },
+    "wmf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw=="
+    },
+    "word": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
+      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA=="
     },
     "wrap-ansi": {
       "version": "3.0.1",
@@ -1482,6 +1774,29 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "xlsx": {
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.16.7.tgz",
+      "integrity": "sha512-Xc4NRjci2Grbh9NDk/XoaWycJurxEug1wwn0aJCmB0NvIMyQuHYq2muWLWGidYNZPf94aUbqm6K8Fbjd7gKTZg==",
+      "requires": {
+        "adler-32": "~1.2.0",
+        "cfb": "^1.1.4",
+        "codepage": "~1.14.0",
+        "commander": "~2.17.1",
+        "crc-32": "~1.2.0",
+        "exit-on-epipe": "~1.0.1",
+        "ssf": "~0.11.2",
+        "wmf": "~1.0.1",
+        "word": "~0.3.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.17.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
+          "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg=="
+        }
+      }
     },
     "yauzl": {
       "version": "2.10.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "test:headless": "$(npm bin)/cypress run --headless"
   },
   "dependencies": {
+    "ckan-client": "git+https://github.com/datopian/ckan-client-js.git",
+    "cypress": "^4.9.0",
     "cypress-file-upload": "^4.0.7",
-    "cypress": "^4.9.0"
+    "frictionless.js": "^0.13.3"
   }
 }


### PR DESCRIPTION
This PR suggests a simple script to call CKAN JavaScript Client and create and push a blob to a resource using CKAN API. In the future, it can be moved to Cypress, but at the moment I am struggling to run async code inside Cypress runner, so this comes in as a _hot fix_ to be reverted soon.